### PR TITLE
remove error message columns in form_type_monthly.csv

### DIFF
--- a/Monthly_Reports/Registrations/data_processing.R
+++ b/Monthly_Reports/Registrations/data_processing.R
@@ -17,6 +17,9 @@ osf_retrieve_file("https://osf.io/z3dg2/") %>%
 
 monthly_data <- read_csv(paste0(here::here('Registrations/'), 'form_type_monthly.csv'))
 
+# # remove error message columns that would otherwise be preserved in each form_type_monthly.csv file
+# monthly_data <- monthly_data[, -(1:3)]
+
 # create monthly numbers for total registrations based on keen daily data
 read_sheet('https://docs.google.com/spreadsheets/d/1ti6iEgjvr-hXyMT5NwCNfAg-PJaczrMUX9sr6Cj6_kM/', 
            col_types = '??iiii') %>%


### PR DESCRIPTION
I added a line to remove the first three columns of the form_type_monthly.csv file when it is read in from the OSF project. I commented this line out because after it is run once, it shouldn't be necessary unless new error messages come up.